### PR TITLE
Use implicit cradle discovery mirroring HLS

### DIFF
--- a/ghc-debug-adapter/Development/Debug/Adapter/Init.hs
+++ b/ghc-debug-adapter/Development/Debug/Adapter/Init.hs
@@ -9,7 +9,6 @@ import qualified Data.Text.IO as T
 import qualified System.Process as P
 import Data.Function
 import Data.Functor
-import Colog.Core (LogAction (..))
 import Control.Monad.IO.Class
 import System.IO
 import GHC.IO.Encoding
@@ -24,6 +23,7 @@ import System.Directory
 import Development.Debug.Adapter
 import Development.Debug.Adapter.Exit
 import Development.Debug.Adapter.Flags
+import Development.Debug.Adapter.Logger
 import qualified Development.Debug.Adapter.Output as Output
 
 import qualified GHC.Debugger as Debugger
@@ -64,7 +64,7 @@ data LaunchArgs
 -- | Initialize debugger
 --
 -- Returns @True@ if successful.
-initDebugger :: LogAction IO T.Text -> LaunchArgs -> DebugAdaptor Bool
+initDebugger :: LogAction IO (WithSeverity T.Text) -> LaunchArgs -> DebugAdaptor Bool
 initDebugger logger LaunchArgs{__sessionId, projectRoot, entryFile, entryPoint, entryArgs, extraGhcArgs} = do
   syncRequests  <- liftIO newEmptyMVar
   syncResponses <- liftIO newEmptyMVar

--- a/ghc-debug-adapter/Development/Debug/Adapter/Init.hs
+++ b/ghc-debug-adapter/Development/Debug/Adapter/Init.hs
@@ -9,6 +9,7 @@ import qualified Data.Text.IO as T
 import qualified System.Process as P
 import Data.Function
 import Data.Functor
+import Colog.Core (LogAction (..))
 import Control.Monad.IO.Class
 import System.IO
 import GHC.IO.Encoding
@@ -63,8 +64,8 @@ data LaunchArgs
 -- | Initialize debugger
 --
 -- Returns @True@ if successful.
-initDebugger ::  LaunchArgs -> DebugAdaptor Bool
-initDebugger LaunchArgs{__sessionId, projectRoot, entryFile, entryPoint, entryArgs, extraGhcArgs} = do
+initDebugger :: LogAction IO T.Text -> LaunchArgs -> DebugAdaptor Bool
+initDebugger logger LaunchArgs{__sessionId, projectRoot, entryFile, entryPoint, entryArgs, extraGhcArgs} = do
   syncRequests  <- liftIO newEmptyMVar
   syncResponses <- liftIO newEmptyMVar
 
@@ -79,7 +80,7 @@ initDebugger LaunchArgs{__sessionId, projectRoot, entryFile, entryPoint, entryAr
                         "). Instead, got " ++ (init{-drops \n-} actualVersion) ++ "."
 
   Output.console $ T.pack "Discovering session flags with hie-bios..."
-  mflags <- liftIO (hieBiosFlags projectRoot entryFile)
+  mflags <- liftIO (hieBiosFlags logger projectRoot entryFile)
   case mflags of
     Left e -> do exitWithMsg e
                  return False

--- a/ghc-debug-adapter/Development/Debug/Adapter/Logger.hs
+++ b/ghc-debug-adapter/Development/Debug/Adapter/Logger.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Simple Logger API using co-log style loggers
+module Development.Debug.Adapter.Logger (
+  LogAction (..),
+  Severity (..),
+  WithSeverity (..),
+  cmap,
+  cmapWithSev,
+
+  -- * Pretty printing of logs
+  renderPrettyWithSeverity,
+  renderWithSeverity,
+  renderPretty,
+  renderSeverity,
+) where
+
+import Colog.Core (LogAction (..), Severity (..), WithSeverity (..))
+import Colog.Core.Action (cmap)
+import Data.Text (Text)
+import Prettyprinter
+import Prettyprinter.Render.Text (renderStrict)
+
+cmapWithSev :: (a -> b) -> LogAction m (WithSeverity b) -> LogAction m (WithSeverity a)
+cmapWithSev f = cmap (fmap f)
+
+renderPrettyWithSeverity :: Pretty a => WithSeverity a -> Text
+renderPrettyWithSeverity =
+  renderWithSeverity renderPretty
+
+renderWithSeverity :: (a -> Text) -> WithSeverity a -> Text
+renderWithSeverity f msgWithSev =
+  renderSeverity (getSeverity msgWithSev) <> " " <> f (getMsg msgWithSev)
+
+renderPretty :: Pretty a => a -> Text
+renderPretty a =
+  let
+    docToText = renderStrict . layoutPretty defaultLayoutOptions
+  in
+    docToText (pretty a)
+
+renderSeverity :: Severity -> Text
+renderSeverity = \ case
+  Debug -> "[DEBUG]"
+  Info -> "[INFO]"
+  Warning -> "[WARNING]"
+  Error -> "[ERROR]"

--- a/ghc-debug-adapter/Main.hs
+++ b/ghc-debug-adapter/Main.hs
@@ -14,6 +14,7 @@ import Development.Debug.Adapter.Stopped
 import Development.Debug.Adapter.Evaluation
 import Development.Debug.Adapter.Exit
 import Development.Debug.Adapter.Handles
+import Development.Debug.Adapter.Logger
 import Development.Debug.Adapter
 
 import System.IO (hSetBuffering, BufferMode(LineBuffering))
@@ -36,7 +37,8 @@ main = do
   withInterceptedStdoutForwarding defaultStdoutForwardingAction $ \realStdout -> do
     hSetBuffering realStdout LineBuffering
     l <- handleLogger realStdout
-    runDAPServerWithLogger (cmap renderDAPLog l) config (talk l)
+    let loggerWithSev = cmap (renderWithSeverity id) l
+    runDAPServerWithLogger (cmap renderDAPLog l) config (talk loggerWithSev)
 
 -- | Fetch config from environment, fallback to sane defaults
 getConfig :: Int -> IO ServerConfig
@@ -90,7 +92,7 @@ getConfig port = do
 -- | Main function where requests are received and Events + Responses are returned.
 -- The core logic of communicating between the client <-> adaptor <-> debugger
 -- is implemented in this function.
-talk :: LogAction IO T.Text -> Command -> DebugAdaptor ()
+talk :: LogAction IO (WithSeverity T.Text) -> Command -> DebugAdaptor ()
 --------------------------------------------------------------------------------
 talk l = \ case
   CommandInitialize -> do

--- a/ghc-debugger.cabal
+++ b/ghc-debugger.cabal
@@ -90,6 +90,7 @@ executable ghc-debug-adapter
                       Development.Debug.Adapter.Evaluation,
                       Development.Debug.Adapter.Init,
                       Development.Debug.Adapter.Interface,
+                      Development.Debug.Adapter.Logger,
                       Development.Debug.Adapter.Output,
                       Development.Debug.Adapter.Exit,
                       Development.Debug.Adapter.Handles,

--- a/ghc-debugger.cabal
+++ b/ghc-debugger.cabal
@@ -75,7 +75,7 @@ library
                       exceptions >= 0.10.9 && < 0.11,
                       bytestring >= 0.12.1 && < 0.13,
                       aeson >= 2.2.3 && < 2.3,
-                      hie-bios >= 0.15 && < 0.17
+                      hie-bios >= 0.15 && < 0.18
 
     hs-source-dirs:   ghc-debugger
     default-language: Haskell2010
@@ -99,9 +99,13 @@ executable ghc-debug-adapter
         exceptions, aeson, bytestring,
         containers, filepath,
         process, mtl, unix,
+        prettyprinter,
 
         ghc-debugger,
         hie-bios,
+        co-log-core,
+        implicit-hie ^>=0.1.4.0,
+        transformers,
 
         directory >= 1.3.9 && < 1.4,
         async >= 2.2.5 && < 2.3,

--- a/ghc-debugger/GHC/Debugger/Stopped.hs
+++ b/ghc-debugger/GHC/Debugger/Stopped.hs
@@ -209,7 +209,7 @@ getVariables vk = do
           Nothing -> return []
           Just ibi -> do
 #if MIN_VERSION_ghc(9,13,20250730)
-            curr_modl <- liftIO $ getBreakSourceMod ibi <$>
+            curr_modl <- liftIO $ bi_tick_mod . getBreakSourceId ibi <$>
                           readIModBreaks (hsc_HUG hsc_env) ibi
 #else
             let curr_modl = ibi_tick_mod ibi
@@ -225,7 +225,7 @@ getVariables vk = do
           Nothing -> return []
           Just ibi -> do
 #if MIN_VERSION_ghc(9,13,20250730)
-            curr_modl <- liftIO $ getBreakSourceMod ibi <$>
+            curr_modl <- liftIO $ bi_tick_mod . getBreakSourceId ibi <$>
                           readIModBreaks (hsc_HUG hsc_env) ibi
 #else
             let curr_modl = ibi_tick_mod ibi
@@ -277,4 +277,3 @@ getTopImported modl = do
 #else
     Just hmi -> return emptyGlobalRdrEnv
 #endif
-


### PR DESCRIPTION
HLS uses customised cradle discovery, which we want to copy to have the same user experience as HLS.
Idea: If a project can be loaded into HLS, then the debugger can be used as well.

Additionally, we add a logger for hie-bios's output.

closes #21 