### PR TITLE
Disable nightly pipeline while it's broken

### DIFF
--- a/.github/workflows/debugger.yaml
+++ b/.github/workflows/debugger.yaml
@@ -51,10 +51,10 @@ jobs:
     continue-on-error: true # Run all jobs in the matrix to the end
     strategy:
       matrix:
-        version: [9.14.0.20250819, latest-nightly]
+        version: [9.14.0.20250819] #, latest-nightly] disable nightly while its broken
         include:
-          - channel: https://ghc.gitlab.haskell.org/ghcup-metadata/ghcup-nightlies-0.0.7.yaml
-            version: latest-nightly
+          # - channel: https://ghc.gitlab.haskell.org/ghcup-metadata/ghcup-nightlies-0.0.7.yaml
+          #   version: latest-nightly
           - channel: https://raw.githubusercontent.com/haskell/ghcup-metadata/refs/heads/develop/ghcup-prereleases-0.0.9.yaml
             version: 9.14.0.20250819
     steps:


### PR DESCRIPTION
This will allow us to make releases while nightlies are down...